### PR TITLE
Fix aim animation not playing on pvp.brake

### DIFF
--- a/assets/data/maps/multibakery/mba-pvp.json
+++ b/assets/data/maps/multibakery/mba-pvp.json
@@ -225,14 +225,14 @@
             "type": "STOP_PVP_BATTLE"
           },
           {
+            "type": "CHANGE_VAR_BOOL",
+            "varName": "tmp.xpcDisableHoming",
+            "changeType": "set",
+            "value": false
+          },
+          {
             "type": "FOR_EACH_PLAYER",
             "steps": [
-              {
-                "type": "CHANGE_VAR_BOOL",
-                "varName": "tmp.xpcDisableHoming",
-                "changeType": "set",
-                "value": false
-              },
               {
                 "type": "RESUME_DEFAULT_BGM",
                 "mode": "SLOW"
@@ -484,15 +484,10 @@
                             "value": true
                           },
                           {
-                            "type": "FOR_EACH_PLAYER",
-                            "steps": [
-                              {
-                                "type": "CHANGE_VAR_BOOL",
-                                "varName": "tmp.xpcDisableHoming",
-                                "changeType": "set",
-                                "value": true
-                              }
-                            ]
+                            "type": "CHANGE_VAR_BOOL",
+                            "varName": "tmp.xpcDisableHoming",
+                            "changeType": "set",
+                            "value": true
                           },
                           {
                             "type": "START_MULTIPLAYER_PVP_BATTLE",

--- a/assets/data/maps/multibakery/mba-pvp.json
+++ b/assets/data/maps/multibakery/mba-pvp.json
@@ -634,6 +634,10 @@
                     "align": "BOTTOM"
                   },
                   {
+                    "type": "WAIT",
+                    "time": 0.1
+                  },
+                  {
                     "type": "SHOW_ANIMATION",
                     "anim": "aim"
                   },

--- a/assets/data/maps/multibakery/mba-pvp.json
+++ b/assets/data/maps/multibakery/mba-pvp.json
@@ -381,6 +381,7 @@
                         "accepted": [
                           {
                             "type": "FOR_EACH_PLAYER",
+                            "players": { "varName": "pvp.players" },
                             "steps": [
                               {
                                 "type": "SHOW_EFFECT",
@@ -413,6 +414,7 @@
                           },
                           {
                             "type": "FOR_EACH_PLAYER",
+                            "players": { "varName": "pvp.players" },
                             "steps": [
                               {
                                 "entity": {
@@ -570,6 +572,7 @@
         "event": [
           {
             "type": "FOR_EACH_PLAYER",
+            "players": { "varName": "pvp.players" },
             "steps": [
               {
                 "type": "SHOW_EFFECT",
@@ -602,6 +605,7 @@
           },
           {
             "type": "FOR_EACH_PLAYER",
+            "players": { "varName": "pvp.players" },
             "steps": [
               {
                 "entity": {


### PR DESCRIPTION
- **Play pvp round animations only for pvp members**
- **Do not wrap CHANGE_VAR_BOOL in FOR_EACH_PLAYER**
- **Fix aim animation not playing on pvp.brake**
