### PR TITLE
Fix dance floor stopping working after pvp battle

### DIFF
--- a/assets/data/maps/multibakery/mba-pvp.json
+++ b/assets/data/maps/multibakery/mba-pvp.json
@@ -1789,6 +1789,7 @@
         "name": "lights",
         "eventType": "INTERRUPTABLE",
         "endCondition": "tmp.pvpBarriers",
+        "forceRunOnMap": true,
         "event": [
           {
             "type": "IF",


### PR DESCRIPTION
This new `EventTrigger` setting `forceRunOnMap` will make sure the event always runs on the map instance and doesn't try to redirect itself to client instance.
Previously, the event got redirected to the player's instance that started the pvp battle, and if the player left the map, the event would stop.